### PR TITLE
Helm Chart - Correct mountPath for config JSON

### DIFF
--- a/deploy/helm/sftp/templates/deployment.yaml
+++ b/deploy/helm/sftp/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           volumeMounts:
           {{- if .Values.configuration }}
             - name: sftp-json
-              mountPath: "/app/config"
+              mountPath: "/app/config/sftp.json"
               subPath: sftp.json
               readOnly: true
           {{- end }}


### PR DESCRIPTION
Currently when specifying a custom configuration via the chart values the deployment will specify an invalid volume mount that will cause an error on pod startup (it tries to mount `sftp.json` to `/app/config` instead of `/app/config/sftp.json`.) This PR corrects that issue :)