### PR TITLE
UserUtil.UserSetPassword: Use single-quotes for escaping

### DIFF
--- a/src/ES.SFTP.Host/Business/Security/UserUtil.cs
+++ b/src/ES.SFTP.Host/Business/Security/UserUtil.cs
@@ -35,7 +35,7 @@ namespace ES.SFTP.Host.Business.Security
                 await ProcessUtil.QuickRun("usermod", $"-p \"*\" {username}");
             else
                 await ProcessUtil.QuickRun("bash",
-                    $"-c \"echo \\\"{username}:{password}\\\" | chpasswd {(passwordIsEncrypted ? "-e" : string.Empty)} \"");
+                    $"-c \"echo '{username}:{password}' | chpasswd {(passwordIsEncrypted ? "-e" : string.Empty)}\"");
         }
 
         public static async Task<int> UserGetId(string username)


### PR DESCRIPTION
bash is otherwise interpreting '$' as variables in encrypted password hash