### PR TITLE
PrepareUserForSftp: Set read-only permissions on authorized_keys file

### DIFF
--- a/src/ES.SFTP.Host/Orchestrator.cs
+++ b/src/ES.SFTP.Host/Orchestrator.cs
@@ -416,7 +416,7 @@ namespace ES.SFTP.Host
                 authKeysBuilder.AppendLine(await File.ReadAllTextAsync(file));
             await File.WriteAllTextAsync(sshAuthKeysPath, authKeysBuilder.ToString());
             await ProcessUtil.QuickRun("chown", $"{user.Username} {sshAuthKeysPath}");
-            await ProcessUtil.QuickRun("chmod", $"600 {sshAuthKeysPath}");
+            await ProcessUtil.QuickRun("chmod", $"400 {sshAuthKeysPath}");
         }
 
         


### PR DESCRIPTION
Prevents users from modifying authorized_keys via SFTP