### PR TITLE
Added non-standard API endpoint for PAM events

### DIFF
--- a/src/ES.SFTP.Host/Dockerfile
+++ b/src/ES.SFTP.Host/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     # - Remove default host keys
     rm -f /etc/ssh/ssh_host_*key*
 WORKDIR /app
-EXPOSE 22 80
+EXPOSE 22 25080
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /src

--- a/src/ES.SFTP.Host/ES.SFTP.Host.csproj
+++ b/src/ES.SFTP.Host/ES.SFTP.Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileTag>emberstack/sftp:dev</DockerfileTag>
     <DockerfileRunArguments>-p 2222:22 --name sftpdev</DockerfileRunArguments>

--- a/src/ES.SFTP.Host/Orchestrator.cs
+++ b/src/ES.SFTP.Host/Orchestrator.cs
@@ -100,7 +100,7 @@ namespace ES.SFTP.Host
             var eventsScriptBuilder = new StringBuilder();
             eventsScriptBuilder.AppendLine("#!/bin/sh");
             eventsScriptBuilder.AppendLine(
-                "curl \"http://localhost/api/events/pam/generic?username=$PAM_USER&type=$PAM_TYPE&service=$PAM_SERVICE\"");
+                "curl \"http://localhost:25080/api/events/pam/generic?username=$PAM_USER&type=$PAM_TYPE&service=$PAM_SERVICE\"");
             await File.WriteAllTextAsync(hookScriptFile, eventsScriptBuilder.ToString());
             await ProcessUtil.QuickRun("chown", $"root:root \"{hookScriptFile}\"");
             await ProcessUtil.QuickRun("chmod", $"+x \"{hookScriptFile}\"");

--- a/src/ES.SFTP.Host/appsettings.Development.json
+++ b/src/ES.SFTP.Host/appsettings.Development.json
@@ -1,9 +1,2 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Debug",
-            "System": "Information",
-            "Microsoft": "Information"
-        }
-    }
 }

--- a/src/ES.SFTP.Host/appsettings.json
+++ b/src/ES.SFTP.Host/appsettings.json
@@ -1,3 +1,10 @@
 {
-    "AllowedHosts": "*"
+    "AllowedHosts": "*",
+    "Kestrel": {
+        "EndPoints": {
+            "Http": {
+                "Url": "http://0.0.0.0:25080"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #14 
Added non-standard API endpoint to avoid collisions with other standard HTTP applications when running as a side-car