### PR TITLE
Add an annotation hook to restart pod after config change

### DIFF
--- a/src/deploy/helm/sftp/templates/deployment.yaml
+++ b/src/deploy/helm/sftp/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
       {{- include "sftp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/configuration: {{ include (print $.Template.BasePath "/config-secret.yaml") . | sha256sum }}
       labels:
         {{- include "sftp.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
We used docker-sftp helm chart and recognized that the configuration changes were not automatically applied when we deployed the helm chart.
A good solution would be to add a config checksum like described here https://helm.sh/docs/howto/charts_tips_and_tricks/