### PR TITLE
Setting primary GID for users to be created from config.

### DIFF
--- a/src/ES.SFTP/Security/UserUtil.cs
+++ b/src/ES.SFTP/Security/UserUtil.cs
@@ -10,10 +10,10 @@ public class UserUtil
         return command.ExitCode == 0 && !string.IsNullOrWhiteSpace(command.Output);
     }
 
-    public static async Task UserCreate(string username, bool noLoginShell = false)
+    public static async Task UserCreate(string username, bool noLoginShell = false, int? gid = null)
     {
         await ProcessUtil.QuickRun("useradd",
-            $"--comment {username} {(noLoginShell ? "-s /usr/sbin/nologin" : string.Empty)} {username}");
+            $"--comment {username} {(noLoginShell ? "-s /usr/sbin/nologin " : string.Empty)}{(gid.HasValue ? "-g " + gid.Value + " " : string.Empty)}{username}");
     }
 
     public static async Task UserDelete(string username, bool throwOnError = true)


### PR DESCRIPTION
Setting primary GID for users to be created from config.

Rather than creating default individual groups for each user when calling `useradd`, the specified GID for that user will be used as the user's primary group. This ensures that files created by that user inside the container are correctly owned by the specified host GID.