### PR TITLE
Fix for #140

### DIFF
--- a/src/ES.SFTP/Configuration/ConfigurationService.cs
+++ b/src/ES.SFTP/Configuration/ConfigurationService.cs
@@ -68,6 +68,7 @@ public class ConfigurationService : IHostedService, IRequestHandler<SftpConfigur
         config.Global.Directories ??= new List<string>();
         config.Global.Logging ??= new LoggingDefinition();
         config.Global.Chroot ??= new ChrootDefinition();
+        config.Global.PKIandPassword ??= new string("");
         config.Global.HostKeys ??= new HostKeysDefinition();
         config.Global.Hooks ??= new HooksDefinition();
 

--- a/src/ES.SFTP/Configuration/Elements/GlobalConfiguration.cs
+++ b/src/ES.SFTP/Configuration/Elements/GlobalConfiguration.cs
@@ -7,6 +7,7 @@ public class GlobalConfiguration
     public LoggingDefinition Logging { get; set; } = new();
     public HostKeysDefinition HostKeys { get; set; } = new();
     public HooksDefinition Hooks { get; set; } = new();
+    public string PKIandPassword { get; set; }
 
     public string Ciphers { get; set; }
     public string HostKeyAlgorithms { get; set; }

--- a/src/ES.SFTP/SSH/Configuration/SSHConfiguration.cs
+++ b/src/ES.SFTP/SSH/Configuration/SSHConfiguration.cs
@@ -12,6 +12,7 @@ public class SSHConfiguration
     public string HostKeyAlgorithms { get; set; }
     public string KexAlgorithms { get; set; }
     public string MACs { get; set; }
+    public string PKIandPassword { get; set; }
 
     public override string ToString()
     {
@@ -43,6 +44,8 @@ public class SSHConfiguration
         builder.AppendLine();
         builder.AppendLine("# Allowed users");
         builder.AppendLine($"AllowUsers {string.Join(" ", AllowUsers)}");
+        builder.AppendLine();
+        if (!string.IsNullOrWhiteSpace(PKIandPassword)) builder.AppendLine("AuthenticationMethods \"publickey,password\"");
         builder.AppendLine();
         builder.AppendLine("# Match blocks");
         foreach (var matchBlock in MatchBlocks)

--- a/src/ES.SFTP/SSH/Configuration/SSHConfiguration.cs
+++ b/src/ES.SFTP/SSH/Configuration/SSHConfiguration.cs
@@ -45,7 +45,7 @@ public class SSHConfiguration
         builder.AppendLine("# Allowed users");
         builder.AppendLine($"AllowUsers {string.Join(" ", AllowUsers)}");
         builder.AppendLine();
-        if (!string.IsNullOrWhiteSpace(PKIandPassword)) builder.AppendLine("AuthenticationMethods \"publickey,password\"");
+        if (PKIandPassword == "true") builder.AppendLine("AuthenticationMethods \"publickey,password\"");
         builder.AppendLine();
         builder.AppendLine("# Match blocks");
         foreach (var matchBlock in MatchBlocks)

--- a/src/ES.SFTP/SSH/SSHService.cs
+++ b/src/ES.SFTP/SSH/SSHService.cs
@@ -65,6 +65,7 @@ public class SSHService : IHostedService, INotificationHandler<ConfigurationChan
             HostKeyAlgorithms = sftpConfig.Global.HostKeyAlgorithms,
             KexAlgorithms = sftpConfig.Global.KexAlgorithms,
             MACs = sftpConfig.Global.MACs
+            PKIandPassword = sftpConfig.Global.PKIandPassword
         };
 
         var exceptionalUsers = sftpConfig.Users.Where(s => s.Chroot != null).ToList();

--- a/src/ES.SFTP/SSH/SSHService.cs
+++ b/src/ES.SFTP/SSH/SSHService.cs
@@ -64,7 +64,7 @@ public class SSHService : IHostedService, INotificationHandler<ConfigurationChan
             Ciphers = sftpConfig.Global.Ciphers,
             HostKeyAlgorithms = sftpConfig.Global.HostKeyAlgorithms,
             KexAlgorithms = sftpConfig.Global.KexAlgorithms,
-            MACs = sftpConfig.Global.MACs
+            MACs = sftpConfig.Global.MACs,
             PKIandPassword = sftpConfig.Global.PKIandPassword
         };
 


### PR DESCRIPTION
I fixed it myself, 
This PR contains code to add an option to require both PKI and password auth on a global level.
By setting PKIandPassword to true in the global scope, it will embed `AuthenticationMethods "publickey,password"` to sshd_config to enforce both methods.

example:
```
{
  "Global": {
    "Chroot": {
      "Directory": "%h",
      "StartPath": "sftp"
    },
    "Directories": ["sftp"],
    "PKIandPassword": "true",
    "Logging": {
      "IgnoreNoIdentificationString": true
    },
    "Hooks": {
      "OnServerStartup": [],
      "OnSessionChange": []
    }
  },
  "Users": [
    {
      "Username": "demo",
      "Password": "demo"
    }
  ],
  "Groups": [
    {
      "Name": "demogroup",
      "Users": ["demo"],
      "GID": 5000
    }
  ]
}
```