### PR TITLE
Changes to allow user-specific umask in the server settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ You can customize the values of the helm deployment by using the following Value
 | `configuration.Users[].GID`                                 | Sets the user's GID. A group is created for this value and the user is included  | `null`                                                  |
 | `configuration.Users[].Chroot`                              | If set, will override global `Chroot` settings for this user.                    | `null`                                                  |
 | `configuration.Users[].Directories`                         | Array of additional directories created for this user                            | `null`                                                  |
+| `configuration.Users[].Umask`                               | If set, will set a user-specific `umask` value for this user.                    | `null`                                                  |
 | `initContainers`                                            | Additional initContainers for the pod                                            | `{}`                                                    |
 | `resources`                                                 | Resource limits                                                                  | `{}`                                                    |
 | `nodeSelector`                                              | Node labels for pod assignment                                                   | `{}`                                                    |

--- a/src/ES.SFTP/Configuration/Elements/UserDefinition.cs
+++ b/src/ES.SFTP/Configuration/Elements/UserDefinition.cs
@@ -15,4 +15,7 @@ public class UserDefinition
     public ChrootDefinition Chroot { get; set; } = new();
     public List<string> Directories { get; set; } = new();
     public List<string> PublicKeys { get; set; } = new();
+
+    // Umask property for user-specific file permissions
+    public string Umask { get; set; }
 }


### PR DESCRIPTION
This adds a new configuration setting that allows setting a specific umask value for each user. The umask is a string variable, but it should be a valid umask value. The config looks like this:
```
"Users": [
        {
            "Username": "user1",
            "Password": "pass1",
            "UID": 1001,
            "GID": 1003,
            "Chroot": {
                "Directory": "/user",
                "StartPath": "drop"
            }
        },
        {
            "Username": "user2",
            "Password": "pass2",
            "UID": 1002,
            "GID": 1016,
            "Chroot": {
                "Directory": "/user",
                "StartPath": "drop"
            },
            "Umask": "002"
        }
    ]
 ```
 and it generates this in the **sshd_config** file:
 ```
 Match User "user2"
X11Forwarding no
AllowTcpForwarding no
ForceCommand internal-sftp -u 002
```

Tested it on a custom image and it allowed me to upload files with `-rw-rw-r--` permissions instead of default `-rw-r--r--` permissions.